### PR TITLE
Fix incorrect default config key name

### DIFF
--- a/src/TaxonomyEditorExtension.php
+++ b/src/TaxonomyEditorExtension.php
@@ -97,7 +97,7 @@ class TaxonomyEditorExtension extends SimpleExtension
         return [
             'fields'     => [],
             'backups'    => [
-                'enabled' => false
+                'enable' => false
             ],
             'permission' => 'files:config'
         ];


### PR DESCRIPTION
If you don't have a config.yml file this throws an extension because the code calls `if ($config['backups']['enable'])` which is not set.